### PR TITLE
Ignore compiled assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# compiled asset
+i8kctl
+
+# vim swap files
+/**/*.swp


### PR DESCRIPTION
This pull request adds an initial version of a `.gitignore` file, which ignores the compiled asset and vim swap files. I did this because I am compiling from source since `i8kutils` is not available as an rpm package. Could be beneficial for others who want to compile from source and pull from upstream without moving the binary around.