### PR TITLE
Correct several problems in i8kmon

### DIFF
--- a/debian/i8kmon.service
+++ b/debian/i8kmon.service
@@ -4,7 +4,11 @@ Documentation=man:i8kmon
 ConditionPathExists=/proc/i8k
 
 [Service]
+ExecStartPre=/usr/local/bin/dell-bios-fan-control/dell-bios-fan-control 0
+ExecStopPost=/usr/local/bin/dell-bios-fan-control/dell-bios-fan-control 1
 ExecStart=/usr/bin/i8kmon --nouserconfig
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/i8kmon.service
+++ b/debian/i8kmon.service
@@ -4,8 +4,6 @@ Documentation=man:i8kmon
 ConditionPathExists=/proc/i8k
 
 [Service]
-ExecStartPre=/usr/local/bin/dell-bios-fan-control/dell-bios-fan-control 0
-ExecStopPost=/usr/local/bin/dell-bios-fan-control/dell-bios-fan-control 1
 ExecStart=/usr/bin/i8kmon --nouserconfig
 Restart=always
 RestartSec=5

--- a/dell-smm-hwmon.conf
+++ b/dell-smm-hwmon.conf
@@ -1,2 +1,2 @@
 # This file must be at /etc/modprobe.d/
-options dell-smm-hwmon restricted=0
+options dell-smm-hwmon restricted=0 force=1

--- a/i8kmon
+++ b/i8kmon
@@ -24,10 +24,12 @@ array set config {
     verbose	0
     timeout	2
     t_high	80
+    num_configs	5
     0		{{0 0}  -1  60  -1  65}
     1		{{1 0}  50  70  55  75}
     2		{{1 1}  60  80  65  85}
-    3		{{2 2}  70 128  75 128}
+    3		{{2 1}  65  85  70  90}
+    4		{{2 2}  70 128  75 128}
 }
 
 array set status {
@@ -71,7 +73,7 @@ proc read_config {} {
     	}
     }
 
-    foreach key {0 1 2 3} {
+    for {set key 0}  {$key < $config(num_configs)} {incr key} {
 	set fans  [lindex $config($key) 0]
 	set lo_ac [lindex $config($key) 1]
 	set hi_ac [lindex $config($key) 2]
@@ -89,7 +91,7 @@ proc read_config {} {
 	}
 
 	# set temperature to 128 to hi_ac and hi_bt at config(3)
-	if {$key == 3} {
+	if {$key ==  [expr $config(num_configs)-1] } {
 	    set hi_ac 128
 	    set hi_bt 128
 	}
@@ -190,9 +192,6 @@ proc fan_control {} {
     set state $status(state)
     set temp  $status(temp)
 
-    # store state because it may change below
-    set actual_state $state
-
     set status(t_low)  [lindex $config($state) $index]
     set status(t_high) [lindex $config($state) [expr $index+1]]
 
@@ -220,9 +219,7 @@ proc fan_control {} {
 	}
     }
 
-    if {$state != $actual_state} {
-	set_fan $state
-    }
+    set_fan $state
 }
 
 proc set_fan {state} {
@@ -249,6 +246,8 @@ proc set_fan {state} {
 
     if {$status(nfans) < 2} { set right "-" }
 
+    if {$left == "-" && $right == "-"} {return}
+    
     if {$config(verbose) > 0} {
         puts "$config(i8kfan) $left $right"
     }

--- a/i8kmon
+++ b/i8kmon
@@ -16,38 +16,34 @@
 # General Public License for more details.
 
 array set config {
-    sysconfig	/etc/i8kmon.conf
-    userconfig	~/.i8kmon
-    i8kfan	/usr/bin/i8kfan
-    acpi    "acpi"
-    use_conf    1
-    verbose	0
-    timeout	2
-    t_high	80
-    num_configs	5
-    0		{{0 0}  -1  60  -1  65}
-    1		{{1 0}  50  70  55  75}
-    2		{{1 1}  60  80  65  85}
-    3		{{2 1}  65  85  70  90}
-    4		{{2 2}  70 128  75 128}
+    sysconfig    /etc/i8kmon.conf
+    userconfig   ~/.i8kmon
+    i8kfan       /usr/bin/i8kfan
+    acpi         "acpi"
+    use_conf     1
+    verbose      0
+    timeout      2
+    t_high       80
+    num_configs  5
+    0            {{0 0}  -1  60  -1  65}
+    1            {{1 0}  50  70  55  75}
+    2            {{1 1}  60  80  65  85}
+    3            {{2 1}  65  85  70  90}
+    4            {{2 2}  70 128  75 128}
 }
 
 array set status {
-    leftspeed	{}
-    rightspeed	{}
-    nfans	2
-    acpi_timer	0
-    state	0
-    temp	0
-    lstate	-2
-    rstate	-2
-    lspeed	0
-    rspeed	0
-    lstuck	0
-    rstuck	0
-    ac		0
-    t_low	0
-    t_high	0
+    leftspeed   {}
+    rightspeed  {}
+    nfans       2
+    acpi_timer  0
+    state       0
+    temp        0
+    lstate      -2
+    rstate      -2
+    ac          0
+    t_low       0
+    t_high      0
 }
 
 proc read_config {} {
@@ -56,10 +52,10 @@ proc read_config {} {
 
     # read system config file
     if {[file exists $config(sysconfig)]} {
-    	source $config(sysconfig)
-	if {$config(verbose) > 0} {
-	    puts "reading system config file"
-	}
+        source $config(sysconfig)
+        if {$config(verbose) > 0} {
+            puts "reading system config file"
+        }
     }
 
     # read user config file
@@ -67,36 +63,36 @@ proc read_config {} {
     if {$config(use_conf) != 0} {
         if {[file exists $config(userconfig)]} {
             source $config(userconfig)
-	    if {$config(verbose) > 0} {
-		puts "reading user config file"
-	    }
-    	}
+            if {$config(verbose) > 0} {
+                puts "reading user config file"
+            }
+        }
     }
 
     for {set key 0}  {$key < $config(num_configs)} {incr key} {
-	set fans  [lindex $config($key) 0]
-	set lo_ac [lindex $config($key) 1]
-	set hi_ac [lindex $config($key) 2]
-	set lo_bt [lindex $config($key) 3]
-	set hi_bt [lindex $config($key) 4]
+        set fans  [lindex $config($key) 0]
+        set lo_ac [lindex $config($key) 1]
+        set hi_ac [lindex $config($key) 2]
+        set lo_bt [lindex $config($key) 3]
+        set hi_bt [lindex $config($key) 4]
 
-	# check that for each key hi temp > lo temp
-	if {$lo_ac > $hi_ac} { set hi_ac [expr $lo_ac + 5]}
-	if {$lo_bt > $hi_bt} { set hi_bt [expr $lo_bt + 5]}
+        # check that for each key hi temp > lo temp
+        if {$lo_ac > $hi_ac} {set hi_ac [expr $lo_ac + 5]}
+        if {$lo_bt > $hi_bt} {set hi_bt [expr $lo_bt + 5]}
 
-	# set temperature to -1 to lo_ac and lo_bt at config(0)
-	if {$key == 0} {
-	    set lo_ac -1
-	    set lo_bt -1
-	}
+        # set temperature to -1 to lo_ac and lo_bt at config(0)
+        if {$key == 0} {
+            set lo_ac -1
+            set lo_bt -1
+        }
 
-	# set temperature to 128 to hi_ac and hi_bt at config(3)
-	if {$key ==  [expr $config(num_configs)-1] } {
-	    set hi_ac 128
-	    set hi_bt 128
-	}
+        # set temperature to 128 to hi_ac and hi_bt at config(3)
+        if {$key == [expr $config(num_configs)-1]} {
+            set hi_ac 128
+            set hi_bt 128
+        }
 
-	set config($key) [list $fans $lo_ac $hi_ac $lo_bt $hi_bt]
+        set config($key) [list $fans $lo_ac $hi_ac $lo_bt $hi_bt]
     }
 }
 
@@ -114,9 +110,7 @@ proc check_status {} {
     global config
     global status
 
-    if {![read_i8k_status]} {
-	return
-    }
+    if {![read_i8k_status]} {return}
 
     fan_control
 }
@@ -125,35 +119,41 @@ proc read_i8k_status {} {
     global config
     global status
 
-    set temp [eval exec "i8kctl temp"]
-    set status(temp) $temp
-    set state [eval exec "i8kctl fan"]
-    set status(lstate) [lindex $state 0]
-    set status(rstate) [lindex $state 1]
+    set status(temp) [eval exec "i8kctl temp"]
 
-    # retrieve probed fans speeds stored on variables and set the correct speed values
-    # using stored values improve performance as it does not requires reading
-    # values all the time from the system, and also from the fact that reading
-    # fan speeds is a slow call that freezes the computer in some Dell laptops models.
-    if {$status(lstate) != -1} {
-	set status(lspeed) [lindex $status(leftspeed) $status(lstate)]
-    } else {
-	set status(lspeed) -1
-    }
-    if {$status(rstate) != -1} {
-	set status(rspeed) [lindex $status(rightspeed) $status(rstate)]
-    } else {
-	set status(rspeed) -1
+    set speed [eval exec "i8kctl speed"]
+    set lspeed [lindex $speed 0]
+    set rspeed [lindex $speed 1]
+
+    # Calculate fan state from probed fans speeds.
+    # It improve performance as it does not requires reading values all the time from the system,
+    # since reading fan speeds is a slow call that freezes the computer in some Dell laptops models.
+    set status(lstate) 0
+    set status(rstate) 0
+    set ldiff_speed "+inf"
+    set rdiff_speed "+inf"
+
+    # Search for nearest value
+    for {set idx_speed 0}  {$idx_speed < 4} {incr idx_speed} {
+        if {[expr abs($lspeed - [lindex $status(leftspeed) $idx_speed]) < $ldiff_speed]} {
+            set ldiff_speed [expr abs($lspeed - [lindex $status(leftspeed) $idx_speed])]
+            set status(lstate) $idx_speed
+        }
+
+        if {[expr abs($rspeed - [lindex $status(rightspeed) $idx_speed]) < $rdiff_speed]} {
+            set rdiff_speed [expr abs($rspeed - [lindex $status(rightspeed) $idx_speed])]
+            set status(rstate) $idx_speed
+        }
     }
 
     # If AC status is not available read it from procfs
     set ac [eval exec "i8kctl ac"]
     if {$ac < 0} {
-	read_ac_status
+        read_ac_status
     }
 
     if {$config(verbose) > 0} {
-        puts "temp, left fan state, right fan state, ac state: $status(temp) $status(lstate) $status(rstate) $status(ac)"
+        puts "temp, \[fan state\], \[fan speed\], ac state:  $status(temp) \[$status(lstate) $status(rstate)\] \[$lspeed $rspeed\] $status(ac)"
     }
 
     return 1
@@ -165,7 +165,7 @@ proc read_ac_status {} {
 
     # Read ac status once per minute
     if {[incr status(acpi_timer) -1] > 0} {
-	return 1
+        return 1
     }
 
     set status(acpi_timer) [expr 60 / $config(timeout)]
@@ -196,27 +196,27 @@ proc fan_control {} {
     set status(t_high) [lindex $config($state) [expr $index+1]]
 
     while {$temp < 128 && $temp >= $status(t_high)} {
-	if {$config(verbose) > 0} {
-	    puts -nonewline "# ($temp>=$status(t_high)), "
-	}
-	incr state
-	set status(t_low)  [lindex $config($state) $index]
-	set status(t_high) [lindex $config($state) [expr $index+1]]
-	if {$config(verbose) > 0} {
-	    puts "state=$state, low=$status(t_low), high=$status(t_high)"
-	}
+        if {$config(verbose) > 0} {
+            puts -nonewline "# ($temp>=$status(t_high)), "
+        }
+        incr state
+        set status(t_low)  [lindex $config($state) $index]
+        set status(t_high) [lindex $config($state) [expr $index+1]]
+        if {$config(verbose) > 0} {
+            puts "state=$state, low=$status(t_low), high=$status(t_high)"
+        }
     }
 
     while {$temp > 0 && $temp <= $status(t_low)} {
-	if {$config(verbose) > 0} {
-	    puts -nonewline "# ($temp<=$status(t_low)), "
-	}
-	incr state -1
-	set status(t_low)  [lindex $config($state) $index]
-	set status(t_high) [lindex $config($state) [expr $index+1]]
-	if {$config(verbose) > 0} {
-	    puts "state=$state, low=$status(t_low), high=$status(t_high)"
-	}
+        if {$config(verbose) > 0} {
+            puts -nonewline "# ($temp<=$status(t_low)), "
+        }
+        incr state -1
+        set status(t_low)  [lindex $config($state) $index]
+        set status(t_high) [lindex $config($state) [expr $index+1]]
+        if {$config(verbose) > 0} {
+            puts "state=$state, low=$status(t_low), high=$status(t_high)"
+        }
     }
 
     set_fan $state
@@ -247,7 +247,7 @@ proc set_fan {state} {
     if {$status(nfans) < 2} { set right "-" }
 
     if {$left == "-" && $right == "-"} {return}
-    
+
     if {$config(verbose) > 0} {
         puts "$config(i8kfan) $left $right"
     }
@@ -272,60 +272,58 @@ proc parse_options {} {
     global argv
 
     for {set i 0} {$i < [llength $argv]} {incr i} {
-	set arg [lindex $argv $i]
-	switch -- $arg {
-	    -\? - -h - -help - --help {
-		usage
-		exit
-	    }
-	    --nouserconfig - -nc {
-		set config(use_conf) 0
-	    }
-	    --verbose - -v {
-		set config(verbose) 1
-	    }
-	    --timeout - -t {
-		set config(timeout) [lindex $argv [incr i]]
-	    }
-	    -- {
-		continue
-	    }
-	    default {
-		puts stderr "invalid option: $arg"
-		exit 1
-	    }
-	}
+        set arg [lindex $argv $i]
+        switch -- $arg {
+            -\? - -h - -help - --help {
+                usage
+                exit
+            }
+            --nouserconfig - -nc {
+                set config(use_conf) 0
+            }
+            --verbose - -v {
+                set config(verbose) 1
+            }
+            --timeout - -t {
+                set config(timeout) [lindex $argv [incr i]]
+            }
+            -- {
+                continue
+            }
+            default {
+                puts stderr "invalid option: $arg"
+                exit 1
+            }
+        }
     }
 
     if {$config(verbose) > 0} {
-	puts "i8kmon"
-	parray config
-	parray status
+        puts "i8kmon"
+        parray config
+        parray status
     }
 }
 
 proc probe_fan_speed {} {
-    global status
     global config
+    global status
 
-    if {$status(leftspeed) != {} || $status(rightspeed) != {}} {
-	return
-    }
+    if {$status(leftspeed) != {} || $status(rightspeed) != {}} {return}
 
     exec $config(i8kfan) 1 1
-    after 1000
+    after 5000
     set speeds [eval exec "i8kctl speed"]
     set lspeed1 [lindex $speeds 0]
     set rspeed1 [lindex $speeds 1]
 
     exec $config(i8kfan) 2 2
-    after 1000
+    after 5000
     set speeds [eval exec "i8kctl speed"]
     set lspeed2 [lindex $speeds 0]
     set rspeed2 [lindex $speeds 1]
 
     exec $config(i8kfan) 3 3
-    after 1000
+    after 5000
     set speeds [eval exec "i8kctl speed"]
     set lspeed3 [lindex $speeds 0]
     set rspeed3 [lindex $speeds 1]
@@ -333,23 +331,21 @@ proc probe_fan_speed {} {
     set status(leftspeed) "0 $lspeed1 $lspeed2 $lspeed3"
     set status(rightspeed) "0 $rspeed1 $rspeed2 $rspeed3"
 
-    if {$config(verbose) > 1} {
-	puts "Probed fan speeds are left=$status(leftspeed), right=status(rightspeed)"
+    if {$config(verbose) > 0} {
+        puts "Probed fan speeds are left=$status(leftspeed), right=status(rightspeed)"
     }
 }
 
-# probe external tools
+# Probe external tools
 proc probe_tools {} {
-    # The possibility of choosing 'acpi' or 'acpitool' is for compatibility
-    # between different architectures: amd64, i386, kFreeBSD
-    # This code below is strictly related on package dependency stated at
-    # keyword 'Depends:' on file 'debian/control'
+    # The possibility of choosing 'acpi' or 'acpitool' is for compatibility between different architectures: amd64, i386, kFreeBSD.
+    # This code below is strictly related on package dependency stated at keyword 'Depends:' on file 'debian/control'.
     if {![catch {exec acpi}]} {
         set config(acpi) "acpi"
     } elseif {[catch {exec acpitool}]} {
         set config(acpi) "acpitool"
     } else {
-        puts stderr "Package dependency problem: neither 'acpi' nor 'acpitool' package is installed"
+        puts stderr "Package dependency problem: neither 'acpi' nor 'acpitool' package is installed."
     }
 }
 

--- a/i8kmon
+++ b/i8kmon
@@ -55,9 +55,9 @@ proc read_config {} {
     # read system config file
     if {[file exists $config(sysconfig)]} {
     	source $config(sysconfig)
-	    if {$config(verbose) > 0} {
-	        puts "reading system config file"
-	    }
+	if {$config(verbose) > 0} {
+	    puts "reading system config file"
+	}
     }
 
     # read user config file
@@ -65,36 +65,36 @@ proc read_config {} {
     if {$config(use_conf) != 0} {
         if {[file exists $config(userconfig)]} {
             source $config(userconfig)
-	        if {$config(verbose) > 0} {
-        		puts "reading user config file"
-	        }
+	    if {$config(verbose) > 0} {
+		puts "reading user config file"
+	    }
     	}
     }
 
     foreach key {0 1 2 3} {
-	    set fans  [lindex $config($key) 0]
-	    set lo_ac [lindex $config($key) 1]
-	    set hi_ac [lindex $config($key) 2]
-	    set lo_bt [lindex $config($key) 3]
-	    set hi_bt [lindex $config($key) 4]
+	set fans  [lindex $config($key) 0]
+	set lo_ac [lindex $config($key) 1]
+	set hi_ac [lindex $config($key) 2]
+	set lo_bt [lindex $config($key) 3]
+	set hi_bt [lindex $config($key) 4]
 
-	    # check that for each key hi temp > lo temp
-	    if {$lo_ac > $hi_ac} { set hi_ac [expr $lo_ac + 5]}
-	    if {$lo_bt > $hi_bt} { set hi_bt [expr $lo_bt + 5]}
+	# check that for each key hi temp > lo temp
+	if {$lo_ac > $hi_ac} { set hi_ac [expr $lo_ac + 5]}
+	if {$lo_bt > $hi_bt} { set hi_bt [expr $lo_bt + 5]}
 
-	    # set temperature to -1 to lo_ac and lo_bt at config(0)
-	    if {$key == 0} {
-	        set lo_ac -1
-	        set lo_bt -1
-	    }
+	# set temperature to -1 to lo_ac and lo_bt at config(0)
+	if {$key == 0} {
+	    set lo_ac -1
+	    set lo_bt -1
+	}
 
-	    # set temperature to 128 to hi_ac and hi_bt at config(3)
-	    if {$key == 3} {
-	        set hi_ac 128
-	        set hi_bt 128
-	    }
+	# set temperature to 128 to hi_ac and hi_bt at config(3)
+	if {$key == 3} {
+	    set hi_ac 128
+	    set hi_bt 128
+	}
 
-	    set config($key) [list $fans $lo_ac $hi_ac $lo_bt $hi_bt]
+	set config($key) [list $fans $lo_ac $hi_ac $lo_bt $hi_bt]
     }
 }
 
@@ -116,7 +116,7 @@ proc check_status {} {
 	return
     }
 
-	fan_control
+    fan_control
 }
 
 proc read_i8k_status {} {
@@ -129,10 +129,10 @@ proc read_i8k_status {} {
     set status(lstate) [lindex $state 0]
     set status(rstate) [lindex $state 1]
 
-    # retrieve probeb fans speeds stored on variables and set the correct speed values
-	# using stored values improve performance as it does not requires reading
-	# values all the time from the system, and also from the fact that reading
-	# fan speeds is a slow call that freezes the computer in some Dell laptops models.
+    # retrieve probed fans speeds stored on variables and set the correct speed values
+    # using stored values improve performance as it does not requires reading
+    # values all the time from the system, and also from the fact that reading
+    # fan speeds is a slow call that freezes the computer in some Dell laptops models.
     if {$status(lstate) != -1} {
 	set status(lspeed) [lindex $status(leftspeed) $status(lstate)]
     } else {
@@ -190,46 +190,46 @@ proc fan_control {} {
     set state $status(state)
     set temp  $status(temp)
 
-	# store state because it maybe will change below
-	set actual_state $state
+    # store state because it may change below
+    set actual_state $state
 
     set status(t_low)  [lindex $config($state) $index]
     set status(t_high) [lindex $config($state) [expr $index+1]]
 
     while {$temp < 128 && $temp >= $status(t_high)} {
-	    if {$config(verbose) > 0} {
-	        puts -nonewline "# ($temp>=$status(t_high)), "
-	    }
-	    incr state
-	    set status(t_low)  [lindex $config($state) $index]
-	    set status(t_high) [lindex $config($state) [expr $index+1]]
-	    if {$config(verbose) > 0} {
-	        puts "state=$state, low=$status(t_low), high=$status(t_high)"
-	    }
+	if {$config(verbose) > 0} {
+	    puts -nonewline "# ($temp>=$status(t_high)), "
+	}
+	incr state
+	set status(t_low)  [lindex $config($state) $index]
+	set status(t_high) [lindex $config($state) [expr $index+1]]
+	if {$config(verbose) > 0} {
+	    puts "state=$state, low=$status(t_low), high=$status(t_high)"
+	}
     }
 
     while {$temp > 0 && $temp <= $status(t_low)} {
-	    if {$config(verbose) > 0} {
-	        puts -nonewline "# ($temp<=$status(t_low)), "
-	    }
-	    incr state -1
-	    set status(t_low)  [lindex $config($state) $index]
-	    set status(t_high) [lindex $config($state) [expr $index+1]]
-	    if {$config(verbose) > 0} {
-	        puts "state=$state, low=$status(t_low), high=$status(t_high)"
-	    }
+	if {$config(verbose) > 0} {
+	    puts -nonewline "# ($temp<=$status(t_low)), "
+	}
+	incr state -1
+	set status(t_low)  [lindex $config($state) $index]
+	set status(t_high) [lindex $config($state) [expr $index+1]]
+	if {$config(verbose) > 0} {
+	    puts "state=$state, low=$status(t_low), high=$status(t_high)"
+	}
     }
 
-	if {$state != $actual_state} {
-        set_fan $state
-	}
+    if {$state != $actual_state} {
+	set_fan $state
+    }
 }
 
 proc set_fan {state} {
     global config
     global status
 
-	set status(state) $state
+    set status(state) $state
     set args [lindex $config($state) 0]
 
     set left [lindex $args 0]
@@ -260,15 +260,11 @@ proc usage {} {
     global argv0
 
     regsub -all {^.*/} $argv0 {} progname
-    puts "Usage:  $progname \[<options>...]
-
-Options:
-
-   -nc|--nouserconfig       don\x27t read \$HOME/.i8kmon
-    -v|--verbose            report log to stdout
-    -t|--timeout <secs>     set poll timeout
-
-"
+    puts "Usage:  $progname \[<options>...]\n"
+    puts "Options:\n"
+    puts "   -nc|--nouserconfig       don\x27t read \$HOME/.i8kmon"
+    puts "    -v|--verbose            report log to stdout"
+    puts "    -t|--timeout <secs>     set poll timeout\n"
 }
 
 proc parse_options {} {
@@ -283,9 +279,9 @@ proc parse_options {} {
 		usage
 		exit
 	    }
-        --nouserconfig - -nc {
-        set config(use_conf) 0
-        }
+	    --nouserconfig - -nc {
+		set config(use_conf) 0
+	    }
 	    --verbose - -v {
 		set config(verbose) 1
 	    }
@@ -311,11 +307,11 @@ proc parse_options {} {
 
 proc probe_fan_speed {} {
     global status
-	global config
+    global config
 
-	if {$status(leftspeed) != {} || $status(rightspeed) != {}} {
-		return
-	}
+    if {$status(leftspeed) != {} || $status(rightspeed) != {}} {
+	return
+    }
 
     exec $config(i8kfan) 1 1
     after 1000
@@ -338,14 +334,13 @@ proc probe_fan_speed {} {
     set status(leftspeed) "0 $lspeed1 $lspeed2 $lspeed3"
     set status(rightspeed) "0 $rspeed1 $rspeed2 $rspeed3"
 
-	if {$config(verbose) > 1} {
-		puts "Probed fan speeds are left=$status(leftspeed), right=status(rightspeed)"
-	}
+    if {$config(verbose) > 1} {
+	puts "Probed fan speeds are left=$status(leftspeed), right=status(rightspeed)"
+    }
 }
 
 # probe external tools
 proc probe_tools {} {
-
     # The possibility of choosing 'acpi' or 'acpitool' is for compatibility
     # between different architectures: amd64, i386, kFreeBSD
     # This code below is strictly related on package dependency stated at
@@ -366,7 +361,6 @@ proc main {} {
     probe_fan_speed
     probe_tools
     parse_options
-    set_fan $status(state)
     status_timer
 }
 
@@ -374,4 +368,3 @@ if {$tcl_interactive == 0} {
     main
     vwait forever
 }
-

--- a/i8kmon.conf
+++ b/i8kmon.conf
@@ -1,29 +1,25 @@
 # Sample i8kmon configuration file (/etc/i8kmon.conf, ~/.i8kmon).
 
-# External program to control the fans
-set config(i8kfan)	/usr/bin/i8kfan
-
-# Report status on stdout, override with --verbose option
-set config(verbose)	0
-
 # Status check timeout (seconds), override with --timeout option
-set config(timeout)	2
+set config(timeout)     2
+
+# Temperature display unit (C/F), override with --unit option
+set config(unit)        C
 
 # Temperature threshold at which the temperature is displayed in red
-set config(t_high)	80
+set config(t_high)      80
+
+# Minimum expected fan speed
+set config(min_speed)   2000
 
 # Temperature thresholds: {fan_speeds low_ac high_ac low_batt high_batt}
-# These were tested on the I8000. If you have a different Dell laptop model
-# you should check the BIOS temperature monitoring and set the appropriate
-# thresholds here. In doubt start with low values and gradually rise them
-# until the fans are not always on when the cpu is idle.
-set config(0)   {{0 0}  -1  55  -1  60}
-set config(1)   {{1 1}  50  65  55  70}
-set config(2)   {{2 2}  60  75  65  80}
-set config(3)   {{2 2}  70 128  75 128}
+set config(0)   {{0 0}  -1  55  -1  55}
+set config(1)   {{0 1}  50  60  50  60}
+set config(2)   {{1 1}  55  65  55  65}
+set config(3)   {{2 2}  65 128  65 128}
 
 # Speed values are set here to avoid i8kmon probe them at every time it starts.
-set status(leftspeed)	"0 1000 2000 3000"
-set status(rightspeed)	"0 1000 2000 3000"
+set status(leftspeed)	"0 2500 5000 5000"
+set status(rightspeed)	"0 2500 5000 5000"
 
 # end of file

--- a/i8kmon.conf
+++ b/i8kmon.conf
@@ -3,20 +3,18 @@
 # Status check timeout (seconds), override with --timeout option
 set config(timeout)     2
 
-# Temperature display unit (C/F), override with --unit option
-set config(unit)        C
-
 # Temperature threshold at which the temperature is displayed in red
 set config(t_high)      80
 
-# Minimum expected fan speed
-set config(min_speed)   2000
+# Number of temperature configurations
+set config(num_configs)  5
 
 # Temperature thresholds: {fan_speeds low_ac high_ac low_batt high_batt}
 set config(0)   {{0 0}  -1  55  -1  55}
 set config(1)   {{0 1}  50  60  50  60}
 set config(2)   {{1 1}  55  65  55  65}
-set config(3)   {{2 2}  65 128  65 128}
+set config(3)   {{1 2}  60  70  60  70}
+set config(4)   {{2 2}  65 128  65 128}
 
 # Speed values are set here to avoid i8kmon probe them at every time it starts.
 set status(leftspeed)	"0 2500 5000 5000"

--- a/i8kmon.conf
+++ b/i8kmon.conf
@@ -1,5 +1,3 @@
-# Sample i8kmon configuration file (/etc/i8kmon.conf, ~/.i8kmon).
-
 # Status check timeout (seconds), override with --timeout option
 set config(timeout)     2
 
@@ -10,9 +8,9 @@ set config(t_high)      80
 set config(num_configs)  5
 
 # Temperature thresholds: {fan_speeds low_ac high_ac low_batt high_batt}
-set config(0)   {{0 0}  -1  55  -1  55}
-set config(1)   {{0 1}  50  60  50  60}
-set config(2)   {{1 1}  55  65  55  65}
+set config(0)   {{0 0}  -1  50  -1  50}
+set config(1)   {{0 1}  45  55  45  55}
+set config(2)   {{1 1}  50  65  50  65}
 set config(3)   {{1 2}  60  70  60  70}
 set config(4)   {{2 2}  65 128  65 128}
 


### PR DESCRIPTION
Disable setting of fan speed before probing CPU temperature.
Add possibility to add more temperature configurations.
Force fan speed modification if the config state is inconsistent with fan speed.
Don't read fan state from BIOS.